### PR TITLE
fix problem with undefined last_status in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The symbols are as follows:
 
     function fish_prompt --description 'Write out the prompt'
 
+      set -l last_status $status
+
       set_color $fish_color_cwd
       echo -n (prompt_pwd)
       set_color normal


### PR DESCRIPTION
Added missing last_status variable for people who just want to copy an example from a README file and could be confused with `test: Missing argument at index 2`.
